### PR TITLE
Support trace-level sampling

### DIFF
--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-honeycomb"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Inanna Malick <inanna@recursion.wtf>"]
 edition = "2018"
 description = "Honeycomb.io tracing layer for multiprocess telemetry"
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 tracing = "0.1.12"
 tracing-core = "0.1.9"
-tracing-distributed =  { path = "../tracing-distributed" , version = "0.2.0"}
+tracing-distributed =  { path = "../tracing-distributed", version = "0.2.0" }
 libhoney-rust = "0.1.3"
 rand = "0.7"
 chrono = "0.4.9"

--- a/tracing-honeycomb/src/lib.rs
+++ b/tracing-honeycomb/src/lib.rs
@@ -66,7 +66,7 @@ pub fn new_honeycomb_telemetry_layer(
     let instance_id: u64 = rand::thread_rng().gen();
     TelemetryLayer::new(
         service_name,
-        HoneycombTelemetry::new(honeycomb_config, 1),
+        HoneycombTelemetry::new(honeycomb_config, None),
         move |tracing_id| SpanId {
             instance_id,
             tracing_id,
@@ -92,12 +92,12 @@ pub fn new_honeycomb_telemetry_layer(
 pub fn new_honeycomb_telemetry_layer_with_trace_sampling(
     service_name: &'static str,
     honeycomb_config: libhoney::Config,
-    sample_rate: usize,
+    sample_rate: u128,
 ) -> TelemetryLayer<HoneycombTelemetry, SpanId, TraceId> {
     let instance_id: u64 = rand::thread_rng().gen();
     TelemetryLayer::new(
         service_name,
-        HoneycombTelemetry::new(honeycomb_config, sample_rate),
+        HoneycombTelemetry::new(honeycomb_config, Some(sample_rate)),
         move |tracing_id| SpanId {
             instance_id,
             tracing_id,

--- a/tracing-honeycomb/src/lib.rs
+++ b/tracing-honeycomb/src/lib.rs
@@ -66,7 +66,38 @@ pub fn new_honeycomb_telemetry_layer(
     let instance_id: u64 = rand::thread_rng().gen();
     TelemetryLayer::new(
         service_name,
-        HoneycombTelemetry::new(honeycomb_config),
+        HoneycombTelemetry::new(honeycomb_config, 1),
+        move |tracing_id| SpanId {
+            instance_id,
+            tracing_id,
+        },
+    )
+}
+
+/// Construct a TelemetryLayer that publishes telemetry to honeycomb.io using the
+/// provided honeycomb config, and sample rate. This function differs from
+/// `new_honeycomb_telemetry_layer` and the `sample_rate` on the
+/// `libhoney::Config` there in an important way. `libhoney` samples `Event`
+/// data, which is individual spans on each trace. This means that using the
+/// sampling logic in libhoney may result in missing event data or incomplete
+/// traces. Calling this function provides trace-level sampling, meaning sampling
+/// decisions are based on a modulo of the traceID, and events in a single trace
+/// will not be sampled differently. If the trace is sampled, then all spans
+/// under it will be sent to honeycomb. If a trace is not sampled, no spans or
+/// events under it will be sent. When using this trace-level sampling, the
+/// `sample_rate` parameter on the `libhoney::Config` should be set to 1, which
+/// is the default.
+///
+/// Specialized to the honeycomb.io-specific SpanId and TraceId provided by this crate.
+pub fn new_honeycomb_telemetry_layer_with_trace_sampling(
+    service_name: &'static str,
+    honeycomb_config: libhoney::Config,
+    sample_rate: usize,
+) -> TelemetryLayer<HoneycombTelemetry, SpanId, TraceId> {
+    let instance_id: u64 = rand::thread_rng().gen();
+    TelemetryLayer::new(
+        service_name,
+        HoneycombTelemetry::new(honeycomb_config, sample_rate),
         move |tracing_id| SpanId {
             instance_id,
             tracing_id,


### PR DESCRIPTION
The libhoney-rust library has a `sample_rate` configuration option,
which provides random sampling of events sent to honeycomb.
Unfortunately, this sampling is done at the event level, rather than the
trace level. This means that spans or events belonging to a single trace
will have separate sampling decisions made for them. This in turn means
that when libhoney's sampling is enabled, traces will never have
complete span information within them. This severely limits the utility
of this sampling.

This proposed change introduces sampling based on the trace ID, meaning
that spans and events which are a part of the same trace will always
have the same sampling decision made for them. This will ensure that a
complete picture of the trace is sent up to honeycomb.

There are no breaking changes in behavior or API in this changeset, you
can still use the sampling logic built into libhoney if desired, but the
new function `new_honeycomb_telemetry_layer_with_trace_sampling` has
been introduced, which creates a telemetry layer that uses this new
sampling logic.

Alternatives:
- Use the `sample_rate` from the `libhoney` config struct as the
  trace-level sample rate, and reset the field to 1 before giving it to
  libhoney. This is undesirable as it makes the current behavior
  impossible to use, however it also makes it impossible to misuse this
  new function by providing a sample_rate to this function, and libhoney
  at the same time.
- Perform this trace-level sampling within `libhoney`. This is
  undesirable as it would require either parsing the traceID from the
  string provided to libhoney, or using a hash of this string. It is
  simpler to do the calculation in this library, where we have the raw
  trace ID. This would also be a breaking change for libhoney, whereas
  here it can be opt-in.

# Example

I ran the following code with `libhoney`'s sample rate set to 5, and the new trace-level sample rate set to 5.

```
fn main() {
    register_global_subscriber();

    for i in 0..10 {
        let s = info_span!("running process loop", i);
        let _g = s.enter();

        register_dist_tracing_root(TraceId::generate(), None).unwrap();

        foo();
    }

    std::thread::sleep(std::time::Duration::from_secs(5));
}

#[instrument]
fn foo() {
    sleep(Duration::from_millis(500));
    bar();
}

#[instrument]
fn bar() {
    sleep(Duration::from_millis(500));
    baz();
}


#[instrument]
fn baz() {
    sleep(Duration::from_millis(500));
}
```

This screenshot illustrates the change in behavior between the current libhoney sampling, and the new trace-level sampling.

![old-vs-new-sampling-behavior](https://user-images.githubusercontent.com/54288692/101095564-f7827d00-3572-11eb-8095-dc1ebb9de23f.jpg)
