### PR TITLE
feat: rework TraceId for honeycomb (breaking change)

### DIFF
--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -21,6 +21,7 @@ libhoney-rust = "0.1.3"
 rand = "0.7"
 chrono = "0.4.9"
 parking_lot = { version = "0.11.1", optional = true }
+uuid = { version = "0.8.1", features = ["v4"] }
 
 [dev-dependencies]
 tracing-attributes = "0.1.5"

--- a/tracing-honeycomb/examples/async_tracing.rs
+++ b/tracing-honeycomb/examples/async_tracing.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::registry;
 
 #[instrument]
 async fn spawn_children(n: u32, process_name: String) {
-    register_dist_tracing_root(TraceId::generate(), None).unwrap();
+    register_dist_tracing_root(TraceId::new(), None).unwrap();
 
     for _ in 0..n {
         spawn_child_process(&process_name).await;


### PR DESCRIPTION
Now can be any opaque string as specified by Honeycomb but will be generated as a UUID V4 and also prefer to be stored as a UUID.

Adds many ways of converting to and from `TraceId`.

This is a breaking change because `format!("{}", trace_id)` now returns a more compressed string encoding of a u128 if you use `TraceId::generate()`.