### PR TITLE
feat: allow the use of parking_lot for RwLock & Mutex

### DIFF
--- a/tracing-distributed/Cargo.toml
+++ b/tracing-distributed/Cargo.toml
@@ -10,11 +10,15 @@ keywords = ["tracing", "instrumentation"]
 license = "MIT"
 readme = "README.md"
 
+[features]
+use_parking_lot = ["parking_lot"]
+
 [dependencies]
 tracing = "0.1.12"
 tracing-core = "0.1.9"
 tracing-subscriber = "0.2.0"
 itertools = "0.9"
+parking_lot = { version = "0.11.1", optional = true }
 
 [dev-dependencies]
 tracing-attributes = "0.1.5"

--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["tracing", "honeycomb", "instrumentation"]
 license = "MIT"
 readme = "README.md"
 
+[features]
+use_parking_lot = ["parking_lot", "tracing-distributed/use_parking_lot"]
+
 [dependencies]
 tracing = "0.1.12"
 tracing-core = "0.1.9"
@@ -17,6 +20,7 @@ tracing-distributed =  { path = "../tracing-distributed" , version = "0.2.0"}
 libhoney-rust = "0.1.3"
 rand = "0.7"
 chrono = "0.4.9"
+parking_lot = { version = "0.11.1", optional = true }
 
 [dev-dependencies]
 tracing-attributes = "0.1.5"

--- a/tracing-honeycomb/src/honeycomb.rs
+++ b/tracing-honeycomb/src/honeycomb.rs
@@ -2,8 +2,12 @@ use crate::visitor::{event_to_values, span_to_values, HoneycombVisitor};
 use libhoney::FieldHolder;
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::Mutex;
 use tracing_distributed::{Event, Span, Telemetry};
+
+#[cfg(not(feature = "use_parking_lot"))]
+use std::sync::Mutex;
+#[cfg(feature = "use_parking_lot")]
+use parking_lot::Mutex;
 
 /// Telemetry capability that publishes events and spans to Honeycomb.io.
 #[derive(Debug)]
@@ -24,7 +28,11 @@ impl HoneycombTelemetry {
 
     fn report_data(&self, data: HashMap<String, ::libhoney::Value>) {
         // succeed or die. failure is unrecoverable (mutex poisoned)
+        #[cfg(not(feature = "use_parking_lot"))]
         let mut client = self.honeycomb_client.lock().unwrap();
+        #[cfg(feature = "use_parking_lot")]
+        let mut client = self.honeycomb_client.lock();
+
         let mut ev = client.new_event();
         ev.add(data);
         let res = ev.send(&mut client);

--- a/tracing-jaeger/Cargo.toml
+++ b/tracing-jaeger/Cargo.toml
@@ -10,13 +10,16 @@ keywords = ["tracing", "opentelemetry", "instrumentation"]
 license = "MIT"
 readme = "README.md"
 
+[features]
+use_parking_lot = ["parking_lot", "tracing-distributed/use_parking_lot"]
+
 [dependencies]
 tracing = "0.1.12"
 tracing-core = "0.1.9"
 tracing-distributed =  { path = "../tracing-distributed" , version = "0.2.0"}
 opentelemetry = "0.5.0"
 rand = "0.7"
-
+parking_lot = { version = "0.11.1", optional = true }
 
 [dev-dependencies]
 tracing-attributes = "0.1.5"

--- a/tracing-jaeger/src/lib.rs
+++ b/tracing-jaeger/src/lib.rs
@@ -21,9 +21,13 @@ use ::opentelemetry::exporter::trace::SpanExporter;
 use ::opentelemetry::sdk::Config;
 use rand::Rng;
 use std::collections::HashMap;
-use std::sync::Mutex;
 #[doc(no_inline)]
 pub use tracing_distributed::{TelemetryLayer, TraceCtxError};
+
+#[cfg(not(feature = "use_parking_lot"))]
+use std::sync::Mutex;
+#[cfg(feature = "use_parking_lot")]
+use parking_lot::Mutex;
 
 /// Register the current span as the local root of a distributed trace.
 ///

--- a/tracing-jaeger/src/opentelemetry.rs
+++ b/tracing-jaeger/src/opentelemetry.rs
@@ -4,8 +4,13 @@ use opentelemetry::sdk::trace::config::Config;
 use opentelemetry::sdk::trace::evicted_hash_map::EvictedHashMap;
 use opentelemetry::sdk::EvictedQueue;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tracing_distributed::{Event, Span, Telemetry};
+
+#[cfg(not(feature = "use_parking_lot"))]
+use std::sync::Mutex;
+#[cfg(feature = "use_parking_lot")]
+use parking_lot::Mutex;
 
 /// Telemetry capability that publishes events and spans to some OpenTelemetry backend
 #[derive(Debug)]
@@ -28,7 +33,10 @@ impl Telemetry for OpenTelemetry {
 
     fn report_span(&self, span: Span<Self::Visitor, Self::SpanId, Self::TraceId>) {
         // succeed or die. failure is unrecoverable (mutex poisoned)
+        #[cfg(not(feature = "use_parking_lot"))]
         let mut events = self.events.lock().unwrap();
+        #[cfg(feature = "use_parking_lot")]
+        let mut events = self.events.lock();
 
         let events = events
             .remove(&span.id)
@@ -40,7 +48,10 @@ impl Telemetry for OpenTelemetry {
     fn report_event(&self, event: Event<Self::Visitor, Self::SpanId, Self::TraceId>) {
         match event.parent_id {
             Some(id) => {
+                #[cfg(not(feature = "use_parking_lot"))]
                 let mut events = self.events.lock().unwrap();
+                #[cfg(feature = "use_parking_lot")]
+                let mut events = self.events.lock();
 
                 if let Some(q) = events.get_mut(&id) {
                     q.append_vec(&mut vec![event_to_values(event)]);


### PR DESCRIPTION
See https://crates.io/crates/parking_lot

Depending on the use-case, `parking_lot` may have better performance, and any uses already using `parking_lot` elsewhere may also want it here.