### PR TITLE
change: always use parking_lot for honeycomb

### DIFF
--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -10,17 +10,14 @@ keywords = ["tracing", "honeycomb", "instrumentation"]
 license = "MIT"
 readme = "README.md"
 
-[features]
-use_parking_lot = ["parking_lot", "tracing-distributed/use_parking_lot"]
-
 [dependencies]
 tracing = "0.1.12"
 tracing-core = "0.1.9"
-tracing-distributed =  { path = "../tracing-distributed", version = "0.2.0" }
+tracing-distributed = { path = "../tracing-distributed", version = "0.2.0", features = ["use_parking_lot"] }
 libhoney-rust = "0.1.3"
 rand = "0.7"
 chrono = "0.4.9"
-parking_lot = { version = "0.11.1", optional = true }
+parking_lot = "0.11.1"
 
 [dev-dependencies]
 tracing-attributes = "0.1.5"

--- a/tracing-honeycomb/src/honeycomb.rs
+++ b/tracing-honeycomb/src/honeycomb.rs
@@ -4,10 +4,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use tracing_distributed::{Event, Span, Telemetry};
 
-#[cfg(feature = "use_parking_lot")]
 use parking_lot::Mutex;
-#[cfg(not(feature = "use_parking_lot"))]
-use std::sync::Mutex;
 
 /// Telemetry capability that publishes events and spans to Honeycomb.io.
 #[derive(Debug)]
@@ -31,10 +28,6 @@ impl HoneycombTelemetry {
     }
 
     fn report_data(&self, data: HashMap<String, ::libhoney::Value>) {
-        // succeed or die. failure is unrecoverable (mutex poisoned)
-        #[cfg(not(feature = "use_parking_lot"))]
-        let mut client = self.honeycomb_client.lock().unwrap();
-        #[cfg(feature = "use_parking_lot")]
         let mut client = self.honeycomb_client.lock();
 
         let mut ev = client.new_event();


### PR DESCRIPTION
As discussed in the feature PR, libhoney-rust uses parking_lot regardless so we might as well do the same.

This removes the `use_parking_lot` feature from tracing-honeycomb.