### PR TITLE
change: full rework of TraceId (breaking change)

### DIFF
--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.7"
 chrono = "0.4.9"
 parking_lot = { version = "0.11.1", optional = true }
 uuid = { version = "0.8.1", features = ["v4"] }
+sha-1 = "0.9.4"
 
 [dev-dependencies]
 tracing-attributes = "0.1.5"

--- a/tracing-honeycomb/Cargo.toml
+++ b/tracing-honeycomb/Cargo.toml
@@ -21,6 +21,7 @@ libhoney-rust = "0.1.3"
 rand = "0.7"
 chrono = "0.4.9"
 parking_lot = { version = "0.11.1", optional = true }
+uuid = { version = "0.8.1", features = ["v4"] }
 
 [dev-dependencies]
 tracing-attributes = "0.1.5"

--- a/tracing-honeycomb/examples/async_tracing.rs
+++ b/tracing-honeycomb/examples/async_tracing.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::registry;
 
 #[instrument]
 async fn spawn_children(n: u32, process_name: String) {
-    register_dist_tracing_root(TraceId::generate(), None).unwrap();
+    register_dist_tracing_root(TraceId::new(), None).unwrap();
 
     for _ in 0..n {
         spawn_child_process(&process_name).await;

--- a/tracing-honeycomb/src/deterministic_sampler.rs
+++ b/tracing-honeycomb/src/deterministic_sampler.rs
@@ -1,0 +1,16 @@
+use sha1::{Digest, Sha1};
+
+use crate::TraceId;
+
+/// A port of beeline-nodejs's code for the same functionality.
+///
+/// Samples deterministically on a given TraceId via a SHA-1 hash.
+///
+/// https://github.com/honeycombio/beeline-nodejs/blob/main/lib/deterministic_sampler.js
+pub(crate) fn sample(sample_rate: u32, trace_id: &TraceId) -> bool {
+    let sum = Sha1::digest(trace_id.as_ref());
+    // Since we are operating on u32's in rust, there is no need for the original's `>>> 0`.
+    let upper_bound = std::u32::MAX / sample_rate;
+
+    u32::from_be_bytes([sum[0], sum[1], sum[2], sum[3]]) <= upper_bound
+}

--- a/tracing-honeycomb/src/honeycomb.rs
+++ b/tracing-honeycomb/src/honeycomb.rs
@@ -1,26 +1,24 @@
 use crate::visitor::{event_to_values, span_to_values, HoneycombVisitor};
 use libhoney::FieldHolder;
-use std::borrow::Cow;
 use std::collections::HashMap;
-use std::convert::{Infallible, TryInto};
-use std::str::FromStr;
 use tracing_distributed::{Event, Span, Telemetry};
-use uuid::Uuid;
 
 #[cfg(feature = "use_parking_lot")]
 use parking_lot::Mutex;
 #[cfg(not(feature = "use_parking_lot"))]
 use std::sync::Mutex;
 
+use crate::{SpanId, TraceId};
+
 /// Telemetry capability that publishes events and spans to Honeycomb.io.
 #[derive(Debug)]
 pub struct HoneycombTelemetry {
     honeycomb_client: Mutex<libhoney::Client<libhoney::transmission::Transmission>>,
-    sample_rate: Option<u128>,
+    sample_rate: Option<u32>,
 }
 
 impl HoneycombTelemetry {
-    pub(crate) fn new(cfg: libhoney::Config, sample_rate: Option<u128>) -> Self {
+    pub(crate) fn new(cfg: libhoney::Config, sample_rate: Option<u32>) -> Self {
         let honeycomb_client = libhoney::init(cfg);
 
         // publishing requires &mut so just mutex-wrap it
@@ -33,7 +31,7 @@ impl HoneycombTelemetry {
         }
     }
 
-    fn report_data(&self, data: HashMap<String, ::libhoney::Value>) {
+    fn report_data(&self, data: HashMap<String, libhoney::Value>) {
         // succeed or die. failure is unrecoverable (mutex poisoned)
         #[cfg(not(feature = "use_parking_lot"))]
         let mut client = self.honeycomb_client.lock().unwrap();
@@ -50,10 +48,11 @@ impl HoneycombTelemetry {
         }
     }
 
-    fn should_report(&self, trace_id: TraceId) -> bool {
-        match self.sample_rate {
-            Some(sample_rate) => trace_id.0 % sample_rate == 0,
-            None => true,
+    fn should_report(&self, trace_id: &TraceId) -> bool {
+        if let Some(sample_rate) = self.sample_rate {
+            crate::deterministic_sampler::sample(sample_rate, trace_id)
+        } else {
+            false
         }
     }
 }
@@ -68,230 +67,16 @@ impl Telemetry for HoneycombTelemetry {
     }
 
     fn report_span(&self, span: Span<Self::Visitor, Self::SpanId, Self::TraceId>) {
-        if self.should_report(span.trace_id) {
+        if self.should_report(&span.trace_id) {
             let data = span_to_values(span);
             self.report_data(data);
         }
     }
 
     fn report_event(&self, event: Event<Self::Visitor, Self::SpanId, Self::TraceId>) {
-        if self.should_report(event.trace_id) {
+        if self.should_report(&event.trace_id) {
             let data = event_to_values(event);
             self.report_data(data);
         }
-    }
-}
-
-/// Unique Span identifier.
-///
-/// Combines a span's `tracing::Id` with an instance identifier to avoid id collisions in distributed scenarios.
-///
-/// `Display` and `FromStr` are guaranteed to round-trip.
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
-pub struct SpanId {
-    pub(crate) tracing_id: tracing::span::Id,
-    pub(crate) instance_id: u64,
-}
-
-impl SpanId {
-    /// Metadata field name associated with `SpanId` values.
-    pub fn meta_field_name() -> &'static str {
-        "span-id"
-    }
-}
-
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub enum ParseSpanIdError {
-    ParseIntError(std::num::ParseIntError),
-    FormatError,
-}
-
-impl FromStr for SpanId {
-    type Err = ParseSpanIdError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut iter = s.split('-');
-        let s1 = iter.next().ok_or(ParseSpanIdError::FormatError)?;
-        let u1 = u64::from_str_radix(s1, 10).map_err(ParseSpanIdError::ParseIntError)?;
-        let s2 = iter.next().ok_or(ParseSpanIdError::FormatError)?;
-        let u2 = u64::from_str_radix(s2, 10).map_err(ParseSpanIdError::ParseIntError)?;
-
-        Ok(SpanId {
-            tracing_id: tracing::Id::from_u64(u1),
-            instance_id: u2,
-        })
-    }
-}
-
-impl std::fmt::Display for SpanId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}-{}", self.tracing_id.into_u64(), self.instance_id)
-    }
-}
-
-/// A Honeycomb Trace ID.
-///
-/// Uniquely identifies a single distributed trace.
-///
-/// `Display` and `FromStr` are guaranteed to round-trip.
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
-pub struct TraceId(TraceIdInner);
-
-#[derive(PartialEq, Eq, Hash, Clone, Debug)]
-pub(crate) enum TraceIdInner {
-    Uuid(Uuid),
-    String(String),
-}
-
-impl TraceId {
-    /// Metadata field name associated with this `TraceId` values.
-    pub fn meta_field_name() -> &'static str {
-        "trace-id"
-    }
-
-    /// Generate a new TraceId backed by a UUID V4.
-    pub fn new() -> Self {
-        TraceId(TraceIdInner::Uuid(Uuid::new_v4()))
-    }
-
-    #[deprecated(
-        since = "0.2",
-        note = "Use `TraceId::new()` instead."
-    )]
-    /// Generate a new TraceId backed by a UUID V4.
-    pub fn generate() -> Self {
-        TraceId(TraceIdInner::Uuid(Uuid::new_v4()))
-    }
-}
-
-impl Into<String> for TraceId {
-    fn into(self) -> String {
-        format!("{}", self)
-    }
-}
-
-impl TryInto<u128> for TraceId {
-    type Error = uuid::Error;
-
-    fn try_into(self) -> Result<u128, Self::Error> {
-        Ok(match self.0 {
-            TraceIdInner::Uuid(uuid) => uuid.as_u128(),
-            TraceIdInner::String(s) => {
-                Uuid::parse_str(&s)?.as_u128()
-            },
-        })
-    }
-}
-
-impl TryInto<Uuid> for TraceId {
-    type Error = uuid::Error;
-
-    fn try_into(self) -> Result<Uuid, Self::Error> {
-        Ok(match self.0 {
-            TraceIdInner::Uuid(uuid) => uuid,
-            TraceIdInner::String(s) => {
-                Uuid::parse_str(&s)?
-            },
-        })
-    }
-}
-
-impl From<Cow<'_, &str>> for TraceId {
-    fn from(s: Cow<'_, &str>) -> Self {
-        Self(TraceIdInner::String(s.to_string()))
-    }
-}
-
-impl From<&str> for TraceId {
-    fn from(s: &str) -> Self {
-        Self(TraceIdInner::String(s.to_string()))
-    }
-}
-
-
-impl From<String> for TraceId {
-    fn from(s: String) -> Self {
-        Self(TraceIdInner::String(s))
-    }
-}
-
-impl From<Uuid> for TraceId {
-    fn from(uuid: Uuid) -> Self {
-        Self(TraceIdInner::Uuid(uuid))
-    }
-}
-
-impl From<u128> for TraceId {
-    fn from(u: u128) -> Self {
-        Self(TraceIdInner::Uuid(Uuid::from_u128(u)))
-    }
-}
-
-impl FromStr for TraceId {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match Uuid::parse_str(s) {
-            Ok(uuid) => Self(TraceIdInner::Uuid(uuid)),
-            Err(_) => Self(TraceIdInner::String(s.to_string())),
-        })
-    }
-}
-
-impl std::fmt::Display for TraceId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.0 {
-            TraceIdInner::Uuid(uuid) => {
-                let buf = &mut [0; 36];
-                let human_id = uuid.to_hyphenated().encode_lower(buf);
-                write!(f, "{}", human_id)
-            },
-            TraceIdInner::String(s) => {
-                write!(f, "{}", s)
-            },
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use proptest::prelude::*;
-    proptest! {
-        #[test]
-        // ua is [1..] and not [0..] because 0 is not a valid tracing::Id (tracing::from_u64 throws on 0)
-        fn span_id_round_trip(ua in 1u64.., ub in 1u64..) {
-            let span_id = SpanId {
-                tracing_id: tracing::Id::from_u64(ua),
-                instance_id: ub,
-            };
-            let s = span_id.to_string();
-            let res = SpanId::from_str(&s);
-            assert_eq!(Ok(span_id), res);
-        }
-
-        #[test]
-        fn trace_id_round_trip_u128(u in 1u128..) {
-            let trace_id: TraceId = u.into();
-            let s = trace_id.to_string();
-            let res = TraceId::from_str(&s);
-            assert_eq!(Ok(trace_id), res);
-        }
-    }
-
-    #[test]
-    fn trace_id_round_trip_str() {
-        let trace_id: TraceId = "a string".into();
-        let s = trace_id.to_string();
-        let res = TraceId::from_str(&s);
-        assert_eq!(Ok(trace_id), res);
-    }
-
-    #[test]
-    fn trace_id_round_trip_empty_str() {
-        let trace_id: TraceId = "".into();
-        let s = trace_id.to_string();
-        let res = TraceId::from_str(&s);
-        assert_eq!(Ok(trace_id), res);
     }
 }

--- a/tracing-honeycomb/src/lib.rs
+++ b/tracing-honeycomb/src/lib.rs
@@ -11,14 +11,21 @@
 //!
 //! As a tracing layer, `TelemetryLayer` can be composed with other layers to provide stdout logging, filtering, etc.
 
+use rand::{self, Rng};
+
 mod honeycomb;
+mod span_id;
+mod trace_id;
 mod visitor;
 
-pub use crate::honeycomb::{HoneycombTelemetry, SpanId, TraceId};
-pub use crate::visitor::HoneycombVisitor;
-use rand::{self, Rng};
+pub use honeycomb::HoneycombTelemetry;
+pub use span_id::SpanId;
+pub use trace_id::TraceId;
 #[doc(no_inline)]
 pub use tracing_distributed::{TelemetryLayer, TraceCtxError};
+pub use visitor::HoneycombVisitor;
+
+pub(crate) mod deterministic_sampler;
 
 /// Register the current span as the local root of a distributed trace.
 ///
@@ -92,7 +99,7 @@ pub fn new_honeycomb_telemetry_layer(
 pub fn new_honeycomb_telemetry_layer_with_trace_sampling(
     service_name: &'static str,
     honeycomb_config: libhoney::Config,
-    sample_rate: u128,
+    sample_rate: u32,
 ) -> TelemetryLayer<HoneycombTelemetry, SpanId, TraceId> {
     let instance_id: u64 = rand::thread_rng().gen();
     TelemetryLayer::new(

--- a/tracing-honeycomb/src/span_id.rs
+++ b/tracing-honeycomb/src/span_id.rs
@@ -1,0 +1,72 @@
+use std::fmt::{self, Display};
+use std::str::FromStr;
+/// Unique Span identifier.
+///
+/// Combines a span's `tracing::Id` with an instance identifier to avoid id collisions in distributed scenarios.
+///
+/// `Display` and `FromStr` are guaranteed to round-trip.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SpanId {
+    pub(crate) tracing_id: tracing::span::Id,
+    pub(crate) instance_id: u64,
+}
+
+impl SpanId {
+    /// Metadata field name associated with `SpanId` values.
+    pub fn meta_field_name() -> &'static str {
+        "span-id"
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ParseSpanIdError {
+    ParseIntError(std::num::ParseIntError),
+    FormatError,
+}
+
+impl FromStr for SpanId {
+    type Err = ParseSpanIdError;
+
+    /// Parses a Span Id from a `{SPAN}-{INSTANCE}` u64 pair, such as `1234567890-1234567890`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut iter = s.split('-');
+        let s1 = iter.next().ok_or(ParseSpanIdError::FormatError)?;
+        let u1 = u64::from_str_radix(s1, 10).map_err(ParseSpanIdError::ParseIntError)?;
+        let s2 = iter.next().ok_or(ParseSpanIdError::FormatError)?;
+        let u2 = u64::from_str_radix(s2, 10).map_err(ParseSpanIdError::ParseIntError)?;
+
+        Ok(SpanId {
+            tracing_id: tracing::Id::from_u64(u1),
+            instance_id: u2,
+        })
+    }
+}
+
+impl Display for SpanId {
+    /// Formats a Span Id as a `{SPAN}-{INSTANCE}` u64 pair, such as `1234567890-1234567890`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}", self.tracing_id.into_u64(), self.instance_id)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use proptest::prelude::*;
+
+    use crate::SpanId;
+
+    proptest! {
+        #[test]
+        // ua is [1..] and not [0..] because 0 is not a valid tracing::Id (tracing::from_u64 throws on 0)
+        fn span_id_round_trip(ua in 1u64.., ub in 1u64..) {
+            let span_id = SpanId {
+                tracing_id: tracing::Id::from_u64(ua),
+                instance_id: ub,
+            };
+            let s = span_id.to_string();
+            let res = SpanId::from_str(&s);
+            assert_eq!(Ok(span_id), res);
+        }
+    }
+}

--- a/tracing-honeycomb/src/trace_id.rs
+++ b/tracing-honeycomb/src/trace_id.rs
@@ -1,0 +1,150 @@
+use std::borrow::Cow;
+use std::convert::{Infallible, TryInto};
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use uuid::Uuid;
+
+/// A Honeycomb Trace ID.
+///
+/// Uniquely identifies a single distributed trace.
+///
+/// Does no parsing on string input values. Can be generated new from a UUID V4.
+///
+/// `Display` and `FromStr` are guaranteed to round-trip.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct TraceId(pub(crate) String);
+
+impl TraceId {
+    /// Metadata field name associated with this `TraceId` values.
+    pub fn meta_field_name() -> &'static str {
+        "trace-id"
+    }
+
+    /// Generate a new `TraceId` from a UUID V4.
+    pub fn new() -> Self {
+        Uuid::new_v4().into()
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `TraceId::new()` instead.")]
+    /// Generate a new `TraceId` from a UUID V4.
+    ///
+    /// Prefer `TraceId::new()`.
+    pub fn generate() -> Self {
+        TraceId::new()
+    }
+}
+
+impl Default for TraceId {
+    fn default() -> Self {
+        TraceId::new()
+    }
+}
+
+impl AsRef<[u8]> for TraceId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl Into<String> for TraceId {
+    fn into(self) -> String {
+        format!("{}", self)
+    }
+}
+
+impl TryInto<u128> for TraceId {
+    type Error = uuid::Error;
+
+    fn try_into(self) -> Result<u128, Self::Error> {
+        Ok(Uuid::parse_str(&self.0)?.as_u128())
+    }
+}
+
+impl TryInto<Uuid> for TraceId {
+    type Error = uuid::Error;
+
+    fn try_into(self) -> Result<Uuid, Self::Error> {
+        Ok(Uuid::parse_str(&self.0)?)
+    }
+}
+
+impl From<Cow<'_, &str>> for TraceId {
+    fn from(s: Cow<'_, &str>) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<&str> for TraceId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for TraceId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<Uuid> for TraceId {
+    fn from(uuid: Uuid) -> Self {
+        let buf = &mut [0; 36];
+        let id = uuid.to_simple().encode_lower(buf);
+        Self(id.to_owned())
+    }
+}
+
+impl From<u128> for TraceId {
+    fn from(u: u128) -> Self {
+        Uuid::from_u128(u).into()
+    }
+}
+
+impl FromStr for TraceId {
+    type Err = Infallible;
+
+    /// Is actually infalliable.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl Display for TraceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        #[test]
+        fn trace_id_round_trip_u128(u in 1u128..) {
+            let trace_id: TraceId = u.into();
+            let s = trace_id.to_string();
+            let res = TraceId::from_str(&s);
+            assert_eq!(Ok(trace_id), res);
+        }
+    }
+
+    #[test]
+    fn trace_id_round_trip_str() {
+        let trace_id: TraceId = "a string".into();
+        let s = trace_id.to_string();
+        let res = TraceId::from_str(&s);
+        assert_eq!(Ok(trace_id), res);
+    }
+
+    #[test]
+    fn trace_id_round_trip_empty_str() {
+        let trace_id: TraceId = "".into();
+        let s = trace_id.to_string();
+        let res = TraceId::from_str(&s);
+        assert_eq!(Ok(trace_id), res);
+    }
+}

--- a/tracing-honeycomb/src/visitor.rs
+++ b/tracing-honeycomb/src/visitor.rs
@@ -1,10 +1,11 @@
-use crate::honeycomb::{SpanId, TraceId};
-use ::libhoney::{json, Value};
 use chrono::{DateTime, Utc};
+use libhoney::{json, Value};
 use std::collections::HashMap;
 use std::fmt;
 use tracing::field::{Field, Visit};
 use tracing_distributed::{Event, Span};
+
+use crate::{SpanId, TraceId};
 
 // Visitor that builds honeycomb-compatible values from tracing fields.
 #[derive(Default, Debug)]


### PR DESCRIPTION
Honeycomb allows it's `trace_id`'s to be _any arbitrary string_. Respect that, because we may be sent an id from some source we do not directly control, such as an edge proxy.

This changes `TraceId` to avoid parsing, and to internally just hold a string. Unfortunately the tracing crate imposes restrictions that make this untenable for span ids.

This also includes a rework of sampling, making it be deterministic for a given `trace_id`, and also allowing it to function on any string.

----

Supersedes https://github.com/inanna-malick/tracing-honeycomb/pull/9

@inanna-malick 